### PR TITLE
Add Security Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -455,7 +455,7 @@ Contributors will be recognized in:
 - **GitHub Issues**: Technical problems and bugs
 - **GitHub Discussions**: General questions and community
 - **Pull Requests**: Code contributions
-- **Email**: [contact info] for security issues
+- **Security**: Please refer to our [Security Policy](SECURITY.md) for reporting vulnerabilities.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of AntiCheatX are currently supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0.0 | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of AntiCheatX seriously. If you believe you have found a security vulnerability, please report it to us privately.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Please send an email to **contact@codenexa.online** with the following information:
+
+1.  **Description**: A detailed description of the vulnerability.
+2.  **Reproduction**: Steps to reproduce the issue (including any proof-of-concept code if available).
+3.  **Impact**: What an attacker could achieve by exploiting this vulnerability.
+4.  **Affected Versions**: Which versions of AntiCheatX are affected.
+
+### Our Process
+
+After receiving your report:
+
+1.  **Acknowledgement**: We will acknowledge receipt of your report within 48 hours.
+2.  **Investigation**: We will investigate the issue and determine its severity.
+3.  **Fix**: If a vulnerability is confirmed, we will work on a fix.
+4.  **Release**: We will release a new version of the plugin containing the fix.
+5.  **Disclosure**: We will coordinate the public disclosure of the vulnerability after a fix has been released and users have had time to update.
+
+We appreciate your help in keeping AntiCheatX secure for everyone!


### PR DESCRIPTION
This change introduces a formal security policy for the AntiCheatX project. It includes a new `SECURITY.md` file that specifies supported versions and provides a private channel (email) for reporting vulnerabilities, following best practices for coordinated vulnerability disclosure. Additionally, the `CONTRIBUTING.md` file has been updated to point users to this new policy when they encounter security-related issues.

---
*PR created automatically by Jules for task [7047996236742936387](https://jules.google.com/task/7047996236742936387) started by @ChamikaSamaraweera*